### PR TITLE
Correct minor spelling error in intro vignette

### DIFF
--- a/pkg/vignettes/intro.Rmd
+++ b/pkg/vignettes/intro.Rmd
@@ -35,7 +35,7 @@ There is also a single verb, namely
 
 
 ### A quick example
-Here's an example demonstrating the typical workflow. We'll use the built-in ```women``` data set (average heights and weighs for American women aged 30-39).
+Here's an example demonstrating the typical workflow. We'll use the built-in ```women``` data set (average heights and weights for American women aged 30-39).
 ```{r }
 data(women)
 summary(women)


### PR DESCRIPTION
Add the missing "t" in "weights" in the sentence "We'll use the built-in `women` data set (average heights and weighs for American women aged 30-39)".