### PR TITLE
Fix error in violating when include_missing = TRUE

### DIFF
--- a/pkg/R/utils.R
+++ b/pkg/R/utils.R
@@ -72,7 +72,7 @@ violating <- function(x, y, include_missing=FALSE, ...){
     stop("Not all rules have record-wise output")
   }
   if (include_missing){
-    x[apply(A,1, function(d) any(!d | is.na(d)) )   ] 
+    x[apply(A, 1, function(d) any(!d | is.na(d))), , drop = FALSE] 
   } else {
     x[apply(A,1,function(d) any(!d &!is.na(d))),,drop=FALSE]
   }


### PR DESCRIPTION
This should fix an error when using the function violating with include_missing = TRUE.
```
rules <- validator(speed >= 0
                 , dist >= 0
                 , speed/dist <= 1.5)
out   <- confront(cars, rules)
violating(cars, out, include_missing = TRUE)
```
This was the error:
Error in `[.data.frame`(x, apply(A, 1, function(d) any(!d | is.na(d)))) : 
  undefined columns selected
