### PR TITLE
Fix spelling in cookbook documentation

### DIFF
--- a/cookbook/01-intro.Rmd
+++ b/cookbook/01-intro.Rmd
@@ -90,7 +90,7 @@ not be interpreted record by record.
 violating(cars, out[1:3])
 ```
 
-We can extract all individual resuls results using for example `as.data.frame`.
+We can extract all individual results using for example `as.data.frame`.
 ```{r}
 df_out <- as.data.frame(out)
 head(df_out, 3)

--- a/cookbook/02-variable_level_checks.Rmd
+++ b/cookbook/02-variable_level_checks.Rmd
@@ -184,7 +184,7 @@ The most general way to check whether a field conforms to a pattern is to use a
 treatment of regular expressions is out of scope for this book, but we will
 give a few examples. A good introduction to regular expressions is given by
 
-> J. Friedl (2006) _Mastering regular expressions._ O'Reilley Media.
+> J. Friedl (2006) _Mastering regular expressions._ O'Reilly Media.
 
 
 In `validate` one can use `grepl` or `field_format`, with the argument `type="regex"`
@@ -207,7 +207,7 @@ Globbing patterns are easier to develop and easier to understand  than regular
 expressions, while regular expressions offer far more flexibility but are
 harder to read. Complex and long regular expressions may have subtle matching
 behaviour that is not immediately obvious to inexperienced users. It is
-therefore advisable to test regular expressions with a a small dataset
+therefore advisable to test regular expressions with a small dataset
 representing realistic cases that contains both matches and non-matches. As a
 rule of thumb we would advise to use globbing patterns unless those offer
 insufficient flexibility.

--- a/cookbook/03-availability-and-uniqueness.Rmd
+++ b/cookbook/03-availability-and-uniqueness.Rmd
@@ -71,7 +71,7 @@ must add up to the annual values.
 The function `is_unique()` checks whether combinations of variables (usually
 key variables) uniquely identify a record. It accepts any positive number of
 variable names and returns `FALSE` for each record that is duplicated with
-respect to the designated variariables.
+respect to the designated variables.
 
 
 Here, we test whether region, period, and measure uniquely identify a value in
@@ -99,7 +99,7 @@ df <- data.frame(x = c(1,1), y = c("A",NA))
 df
 ```
 How should we judge whether these two records are unique?  A tempting option is
-to say the the first record is unique, and to return `NA` for the second record
+to say the first record is unique, and to return `NA` for the second record
 since it contains a missing value: R has the habit of returning `NA` from
 calculations when an input value is `NA`. This choice is not invalid, but it
 would have consequences for determining whether the first record is unique as
@@ -107,7 +107,7 @@ well. After all, it is possible to fill in a value in the missing field such
 that the two records are duplicates. Therefore, if one would return `NA` for
 the second record, the correct thing to do is to also return `NA` for the first
 record. In R, the choice is made to treat `NA` as an actual value when checking
-for duplicates or uniqe records (see `?duplicated` from base R). To see this
+for duplicates or unique records (see `?duplicated` from base R). To see this
 inspect the following code and output.
 ```{r}
 df <- data.frame(x=rep(1,3), y = c("A", NA, NA))

--- a/cookbook/07-working.Rmd
+++ b/cookbook/07-working.Rmd
@@ -9,7 +9,7 @@ source("chunk_opts.R")
 library(validate)
 ```
 
-In this section we dive deeper into the the central object types used in the
+In this section we dive deeper into the central object types used in the
 package: the `validator` object type for storing lists of rules, and the
 `confrontation` object type for storing the results of a validation.
 

--- a/cookbook/09-sdmx.Rmd
+++ b/cookbook/09-sdmx.Rmd
@@ -189,7 +189,7 @@ the [OECD](https://data.oecd.org/api/) (in
   [SDMX-ML](https://data.oecd.org/api/sdmx-ml-documentation/) format),
 [Eurostat](https://ec.europa.eu/eurostat/web/sdmx-infospace),
 the International Labour Organisation [ILO (`https://www.ilo.org/sdmx/index.html`)],
-the [Worldbank](https://datahelpdesk.worldbank.org/knowledgebase/articles/1886701-sdmx-api-queries),
+the [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/articles/1886701-sdmx-api-queries),
 the Bank for International Settlements 
 ([BIS](https://www.bis.org/statistics/sdmx_techspec.htm?accordion1=1&m=6%7C346%7C718)),
 and the Italian Office of National Statistics (ISTAT).

--- a/cookbook/10-comparing.Rmd
+++ b/cookbook/10-comparing.Rmd
@@ -44,7 +44,7 @@ The missing ones are decomposed into those that were already missing in the
 input data and those that are still missing. Similarly, the available values
 can be decomposed into those that were missing before and have been imputed.
 And those that already were available can be decomposed in those that are the
-same as before (unadapted) and those that ave been changed (adapted).
+same as before (unadapted) and those that have been changed (adapted).
 
 
 With the `validate` package, these numbers can be computed for two or more

--- a/cookbook/index.Rmd
+++ b/cookbook/index.Rmd
@@ -66,7 +66,7 @@ with the `validate` package.  Chapters \@ref(sect-work) and
 \@ref(sect-comparing) discusses how to compare two or more versions of a
 dataset, possibly automated through the
 [lumberjack](https://cran.r-project.org/package=lumberjack) package.  The
-section with Biblographical Notes lists some references and points out some
+section with Bibliographical Notes lists some references and points out some
 literature for further reading.
 
 
@@ -93,15 +93,15 @@ To cite this cookbook, please use the following citation.
 ## Acknowledgements {-}
 
 This work was partially funded by European Grant Agreement 88287--NL-VALIDATION
-of the European Statistcal System.
+of the European Statistical System.
 
 
 ## Contributing {-}
 
 If you find a mistake, or have some suggestions, please file an issue or a pull
-request on the github page of the package:
+request on the GitHub page of the package:
 [https://github.com/data-cleaning/validate](https://github.com/data-cleaning/validate).
-If you do not have or want a github account, you can contact the author via the
+If you do not have or want a GitHub account, you can contact the author via the
 e-mail address that is listed with the package.
 
 


### PR DESCRIPTION
Fixed spelling mistakes in the cookbook documentation e.g. removing duplicated words.