### PR TITLE
Fix yaml.R not being able to read rules files with three dashes

### DIFF
--- a/pkg/R/yaml.R
+++ b/pkg/R/yaml.R
@@ -83,7 +83,7 @@ is_r <- function(string){
 
 # find yaml documents and parse them
 yaml_blocks <- function(lines){
-  S <- strsplit(x = paste0(lines,collapse="\n"), split="---[[:blank:]]*\\n?")[[1]]
+  S <- strsplit(x = paste0(lines,collapse="\n"), split="(^|\\n)---[[:blank:]]*\\n?")[[1]]
   S <- Filter(function(x) nchar(x)>0,S)
   lapply(S, function(s){ 
     if ( is_yaml(s)  && valid_yaml(s) ){ 

--- a/pkg/inst/tinytest/test_validator.R
+++ b/pkg/inst/tinytest/test_validator.R
@@ -68,6 +68,12 @@
   v <- validator(x + y > 0)
   F <- plot(v)
 
+## validator works with rule containing ---
+v <- validator(x %in% c("---"))
+export_yaml(v, file = "yamltests/tricky_rules.yaml")
+v_2 <- validator(.file = "yamltests/tricky_rules.yaml")
+expect_equal(length(validator), 1)
+file.remove("yamltests/tricky_rules.yaml")
 
 ## rules are checked when reading from file
 expect_warning(r <- validator(.file="txttests/rules.R"))


### PR DESCRIPTION
Yaml.R uses a regex to split a read yaml file in order to seperate the options which can occur in a file from the rest of the file, which should contain the rules. This regex was not strict enough, causing it to also match on three dashes used in the middle of a rules expression. This commit makes the regex stricter, fixing this issue.

Should fix issue #188 