### PR TITLE
Close issue #194 allow for startsWith and endsWith

### DIFF
--- a/cookbook/02-variable_level_checks.Rmd
+++ b/cookbook/02-variable_level_checks.Rmd
@@ -201,6 +201,9 @@ as: the string starts (`"^"`) with `"sc"`, is followed by a number between 0
 and 9 (`"[0-9]"`) and then ends (`"$"`). The regular expression `"^RET\\{d}2"`
 indicates that a string must start (`"^"`) with `"RET"`, followed by two
 digits (`"\\d{2}"`), after which the string must end (`"$"`).
+For simpler, static, patterns `startsWith` and `endsWith` are also available. 
+Though less flexible than `grepl` and `field_format` using either of these functions
+can arguably lead to validator syntax that is easier to read and understand.
 
 
 Globbing patterns are easier to develop and easier to understand  than regular

--- a/pkg/R/parse.R
+++ b/pkg/R/parse.R
@@ -372,9 +372,9 @@ linear_call <- function(x){
 
 validating_call <- function(cl){
   pure <- c("<", "<=", "==", "!=", ">=", ">", "%in%", "%vin%", "identical", "~" ,"%->%"
-          , "grepl" , "is_unique", "all_unique", "is_complete", "all_complete"
-          , "exists_any", "exists_one", "is_linear_sequence","in_linear_sequence" 
-          , "part_whole_relation","hierarchy"
+          , "grepl", "startsWith", "endsWith", "is_unique", "all_unique", "is_complete"
+          , "all_complete", "exists_any", "exists_one", "is_linear_sequence"
+          , "in_linear_sequence", "part_whole_relation","hierarchy"
           , "field_length", "number_format", "field_format"
           , "contains_exactly", "contains_at_least", "contains_at_most", "does_not_contain"
           , "in_range", "var_group")

--- a/pkg/R/syntax.R
+++ b/pkg/R/syntax.R
@@ -38,7 +38,7 @@
 #' 
 #' @section Text search:
 #' 
-#' \code{grepl} is a validating expression.
+#' \code{grepl}, \code{startsWith} and \code{endsWith} are validating expression.
 #' 
 #' @section Functional dependencies:
 #' 

--- a/pkg/inst/tinytest/test_gh_issue_194.R
+++ b/pkg/inst/tinytest/test_gh_issue_194.R
@@ -1,0 +1,11 @@
+## issue #194 is solved ----
+data <- data.frame(FRUIT = c("apple", "banana", "pear"))
+
+expect_silent(starts_rule <- validator(startsWith(FRUIT, "a")))
+expect_silent(ends_rule <- validator(endsWith(FRUIT, "a")))
+
+cf_starts <- as.data.frame(confront(data, starts_rule))
+cf_ends <- as.data.frame(confront(data, ends_rule))
+
+expect_equal(cf_starts$value, c(TRUE, FALSE, FALSE))
+expect_equal(cf_ends$value, c(FALSE, TRUE, FALSE))


### PR DESCRIPTION
Hi Mark,

Changes to close [#194](https://github.com/data-cleaning/validate/issues/194) submitted by @edwindj  and update documentation accordingly.
- update syntax.R: documentation of allowed text functions
- update parse.R: allow for the base functions `startsWith`, `endsWith`
- update cookbook.Rmd: refer to newly allowed functions on top of `grepl` and `field_format`
- create tinytest file to check if added functions are allowed (all tests keep passing)

Hope I changed everything that needed to be changed, but I'll leave that up to you.
